### PR TITLE
Change option param name pdfoption to pdf_option

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -18,25 +18,25 @@ import {
 
 interface getQuerystring {
   url: string
-  pdfoption?: string
+  pdf_option?: string
 }
 
 interface postBody {
   html: string
-  pdfoption?: string
+  pdf_option?: string
 }
 
 const getSchema = {
   querystring: {
     url: { type: 'string' },
-    pdfoption: { type: ['null', 'string'] },
+    pdf_option: { type: ['null', 'string'] },
   },
 }
 
 const postSchema = {
   body: {
     html: { type: 'string' },
-    pdfoption: { type: ['null', 'string'] },
+    pdf_option: { type: ['null', 'string'] },
   },
 }
 
@@ -129,7 +129,7 @@ export const app = async (
       return
     }
     const pdfOptionsQuery =
-      request.query.pdfoption ?? defaultPdfOptionPresetName
+      request.query.pdf_option ?? defaultPdfOptionPresetName
     const pdfOptions = pdfOptionsPreset.get(pdfOptionsQuery)
     const buffer = await page.pdf(pdfOptions)
     reply.headers(createPDFHttpHeader(buffer))
@@ -149,7 +149,7 @@ export const app = async (
       reply.code(400).send({ error: 'html is required' })
       return
     }
-    const pdfOptionsQuery = body.pdfoption ?? defaultPdfOptionPresetName
+    const pdfOptionsQuery = body.pdf_option ?? defaultPdfOptionPresetName
     const page = server.getHcPage()
     await page.setContent(html, { waitUntil: ['domcontentloaded'] })
     const pdfOptions = pdfOptionsPreset.get(pdfOptionsQuery)

--- a/src/app.ts
+++ b/src/app.ts
@@ -158,7 +158,7 @@ export const app = async (
     reply.send(buffer)
   })
 
-  server.get('/pdfoptions', (_, reply) => {
+  server.get('/pdf_options', (_, reply) => {
     reply.send(pdfOptionsPreset.preset)
   })
 

--- a/test/requests/get.test.ts
+++ b/test/requests/get.test.ts
@@ -19,7 +19,7 @@ async function getFirstPresetName() {
 }
 
 test('request test', async (t) => {
-  t.test('/pdfoptions response is match', async (t) => {
+  t.test('/pdf_options response is match', async (t) => {
     const app = await build(t)
     const pdfOptionsPreset = new PDFOptionsPreset({
       filePath: PDF_OPTION_PRESET_FILE_PATH,
@@ -28,7 +28,7 @@ test('request test', async (t) => {
     const preset = pdfOptionsPreset.preset
     const res = await app.inject({
       method: 'GET',
-      url: '/pdfoptions',
+      url: '/pdf_options',
     } as InjectOptions)
     t.equal(res.payload, JSON.stringify(preset))
     t.end()
@@ -41,7 +41,7 @@ test('request test', async (t) => {
       method: 'GET',
       url: '/',
       query: {
-        pdfoption: pdfOptionName,
+        pdf_option: pdfOptionName,
         url: '',
       },
     } as InjectOptions)
@@ -70,7 +70,7 @@ test('request test', async (t) => {
       method: 'GET',
       url: '/',
       query: {
-        pdfoption: pdfOptionName,
+        pdf_option: pdfOptionName,
         url: TEST_TARGET_URL,
       },
     } as InjectOptions)

--- a/test/requests/post.test.ts
+++ b/test/requests/post.test.ts
@@ -49,7 +49,7 @@ test('POST request test', async (t) => {
       method: 'POST',
       url: '/',
       body: {
-        pdfoption: pdfOptionName,
+        pdf_option: pdfOptionName,
         html: TEST_POST_HTML,
       },
     } as InjectOptions)


### PR DESCRIPTION
Change GET or POST parameter key `pdfoption` to `pdf_option`.
For compatibility with hcep-pdf-server and readability .