### PR TITLE
Use Generics to return value of runOnPage callback

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -113,10 +113,10 @@ export const app = async (
         const buffer = await page.pdf(pdfOptions)
         return buffer
       })
-
       reply.headers(createPDFHttpHeader(buffer))
       reply.send(buffer)
     } catch (error) {
+      console.error(`error ${error}`)
       reply.code(500).send({ error, url })
       return
     }
@@ -149,7 +149,7 @@ export const app = async (
       reply.headers(createPDFHttpHeader(buffer))
       reply.send(buffer)
     } catch (error) {
-      console.error(`werror ${error}`)
+      console.error(`error ${error}`)
       reply.code(500).send({ error })
       return
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -107,7 +107,7 @@ export const app = async (
     const pdfOptionsQuery =
       request.query.pdf_option ?? defaultPresetPdfOptionsName
     try {
-      const buffer = await server.runOnPage(async (page: Page) => {
+      const buffer = await server.runOnPage<Buffer>(async (page: Page) => {
         await page.goto(url)
         const pdfOptions = server.getPDFOptions(pdfOptionsQuery)
         const buffer = await page.pdf(pdfOptions)
@@ -139,13 +139,11 @@ export const app = async (
     const pdfOptions = server.getPDFOptions(pdfOptionsQuery)
 
     try {
-      const buffer = await server.runOnPage(async (page: Page) => {
+      const buffer = await server.runOnPage<Buffer>(async (page: Page) => {
         await page.setContent(html, { waitUntil: ['domcontentloaded'] })
-
         const buffer = await page.pdf(pdfOptions)
         return buffer
       })
-
       reply.headers(createPDFHttpHeader(buffer))
       reply.send(buffer)
     } catch (error) {

--- a/src/plugins/hc-pages.ts
+++ b/src/plugins/hc-pages.ts
@@ -124,9 +124,12 @@ async function plugin(
 ) {
   const hcPages = new HCPages(options)
   await hcPages.init()
-  fastify.decorate('runOnPage', async (callback: RunOnPageCallback) => {
-    return await hcPages.runOnPage(callback)
-  })
+  fastify.decorate(
+    'runOnPage',
+    async (callback: RunOnPageCallback<unknown>) => {
+      return await hcPages.runOnPage(callback)
+    }
+  )
   fastify.decorate('destroyHcPages', async () => {
     await hcPages.destroy()
   })

--- a/src/plugins/hc-pages.ts
+++ b/src/plugins/hc-pages.ts
@@ -1,8 +1,7 @@
 import { FastifyInstance } from 'fastify'
 import { launch, ChromeArgOptions, Page, Browser } from 'puppeteer'
 import fp from 'fastify-plugin'
-import { HcPageConfig } from '../types/hc-pages'
-type RunOnPageCallback = (page: Page) => Promise<Buffer>
+import { HcPageConfig, RunOnPageCallback } from '../types/hc-pages'
 
 export class HCPages {
   private pages: Page[]
@@ -30,16 +29,16 @@ export class HCPages {
     await this.closeBrowser()
   }
 
-  private async runCallback(
+  private async runCallback<T>(
     page: Page,
-    callback: RunOnPageCallback
-  ): Promise<Buffer> {
+    callback: RunOnPageCallback<T>
+  ): Promise<T> {
     const result = await callback(page)
     this.readyPages.push(page)
     return result
   }
 
-  async runOnPage(callback: RunOnPageCallback): Promise<Buffer> {
+  async runOnPage<T>(callback: RunOnPageCallback<T>): Promise<T> {
     let page = this.readyPages.pop()
     while (!page) {
       await Promise.race(this.currentPromises)

--- a/src/types/hc-pages.d.ts
+++ b/src/types/hc-pages.d.ts
@@ -9,7 +9,7 @@ interface HcPageConfig {
   viewport?: Viewport
 }
 
-type RunOnPageCallback<T = Buffer> = (page: Page) => Promise<T>
+type RunOnPageCallback<T> = (page: Page) => Promise<T>
 declare module 'fastify' {
   interface FastifyInstance {
     runOnPage<T>(callback: RunOnPageCallback<T>): Promise<T>

--- a/src/types/hc-pages.d.ts
+++ b/src/types/hc-pages.d.ts
@@ -1,4 +1,4 @@
-import { Viewport } from 'puppeteer'
+import { Viewport, Page } from 'puppeteer'
 
 interface HcPageConfig {
   pagesNum: number
@@ -9,9 +9,10 @@ interface HcPageConfig {
   viewport?: Viewport
 }
 
+type RunOnPageCallback<T = Buffer> = (page: Page) => Promise<T>
 declare module 'fastify' {
   interface FastifyInstance {
-    runOnPage(callback: unknown): Buffer
+    runOnPage<T>(callback: RunOnPageCallback<T>): Promise<T>
     destroyHcPages(): Promise<void>
   }
 }

--- a/test/plugins/hc-pages.test.ts
+++ b/test/plugins/hc-pages.test.ts
@@ -11,5 +11,6 @@ test('enable options', async (t) => {
     acceptLanguage: 'ja',
   })
   await hcPages.init()
+  t.equal((await hcPages.createPages()).length, pagesNum)
   await hcPages.destroy()
 })


### PR DESCRIPTION
Add type to runOnPage with generics.
Make logs the same for POST and GET.