### PR TITLE
use node:15-buster-slim as base image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,31 @@
 # https://github.com/uyamazak/hc-pdf-server
-FROM node:15-alpine3.12 as package_install
+FROM node:15-buster-slim as package_install
 LABEL maintainer="uyamazak<yu.yamazaki85@gmail.com>"
 COPY package.json yarn.lock /app/
 WORKDIR /app
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-  PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
-RUN yarn install --frozen-lockfile
+  PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+RUN ["yarn", "install", "--frozen-lockfile"]
 
-FROM node:15-alpine3.12
-LABEL maintainer="uyamazak<yu.yamazaki85@gmail.com>"
 
+FROM node:15-buster-slim
 # Fastify in docker needs 0.0.0.0
 # https://github.com/fastify/fastify/issues/935
 ENV HCPDF_SERVER_ADDRESS=0.0.0.0
 
-# Install fonts by apk https://wiki.alpinelinux.org/wiki/Fonts
+# Install fonts from debian packages https://packages.debian.org/stable/fonts/
 ARG ADDITONAL_FONTS=""
 
-# https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-on-alpine
-# Installs latest Chromium package.
-RUN apk add --no-cache \
-  chromium \
-  nss \
-  freetype \
-  freetype-dev \
-  harfbuzz \
-  ca-certificates \
-  ttf-freefont ${ADDITONAL_FONTS}
+# https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-puppeteer-in-docker
+RUN apt-get update \
+  && apt-get install -y wget gnupg \
+  && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+  && apt-get update && apt-get upgrade -y \
+  && apt-get install -y google-chrome-stable ${ADDITONAL_FONTS} fonts-freefont-ttf libxss1 \
+  --no-install-recommends \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install fonts from files
 COPY fonts/* /usr/share/fonts/
@@ -35,27 +33,28 @@ RUN fc-cache -fv
 
 # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+  PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
+
+EXPOSE 8080
+
+# Install puppeteer so it's available in the container.
+RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+  && mkdir -p /home/pptruser/Downloads \
+  && mkdir -p /app \
+  && chown -R pptruser:pptruser /home/pptruser \
+  && chown -R pptruser:pptruser /app
 
 WORKDIR /app
-COPY --from=package_install /app/node_modules /app/node_modules
-COPY src/ /app/src
-COPY test/ /app/test
-COPY package.json \
+COPY --chown=pptruser:pptruser --from=package_install /app/node_modules /app/node_modules
+COPY --chown=pptruser:pptruser src/ /app/src
+COPY --chown=pptruser:pptruser test/ /app/test
+COPY --chown=pptruser:pptruser package.json \
   tsconfig.json \
   tsconfig.build.json \
   tsconfig.eslint.json \
   .prettierrc.js \
   /app/
 RUN yarn build
-
-EXPOSE 8080
-
-# Add user so we don't need --no-sandbox.
-RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
-  && mkdir -p /home/pptruser/Downloads /app \
-  && chown -R pptruser:pptruser /home/pptruser \
-  && chown -R pptruser:pptruser /app
 
 # Run everything after as non-privileged user.
 USER pptruser

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,63 @@
+# https://github.com/uyamazak/hc-pdf-server
+FROM node:15-alpine3.12 as package_install
+LABEL maintainer="uyamazak<yu.yamazaki85@gmail.com>"
+COPY package.json yarn.lock /app/
+WORKDIR /app
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+  PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+RUN yarn install --frozen-lockfile
+
+FROM node:15-alpine3.12
+LABEL maintainer="uyamazak<yu.yamazaki85@gmail.com>"
+
+# Fastify in docker needs 0.0.0.0
+# https://github.com/fastify/fastify/issues/935
+ENV HCPDF_SERVER_ADDRESS=0.0.0.0
+
+# Install fonts by apk https://wiki.alpinelinux.org/wiki/Fonts
+ARG ADDITONAL_FONTS=""
+
+# https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#running-on-alpine
+# Installs latest Chromium package.
+RUN apk add --update --no-cache \
+  chromium \
+  nss \
+  freetype \
+  freetype-dev \
+  harfbuzz \
+  ca-certificates \
+  ttf-freefont ${ADDITONAL_FONTS}
+
+# Install fonts from files
+COPY fonts/* /usr/share/fonts/
+RUN fc-cache -fv
+
+# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
+WORKDIR /app
+COPY --from=package_install /app/node_modules /app/node_modules
+COPY src/ /app/src
+COPY test/ /app/test
+COPY package.json \
+  tsconfig.json \
+  tsconfig.build.json \
+  tsconfig.eslint.json \
+  .prettierrc.js \
+  /app/
+RUN yarn build
+
+EXPOSE 8080
+
+# Add user so we don't need --no-sandbox.
+RUN addgroup -S pptruser && adduser -S -g pptruser pptruser \
+  && mkdir -p /home/pptruser/Downloads /app \
+  && chown -R pptruser:pptruser /home/pptruser \
+  && chown -R pptruser:pptruser /app
+
+# Run everything after as non-privileged user.
+USER pptruser
+
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Of course, Docker is also supported!
 
 - Writing in TypeScript
 - Use [Fasity](https://www.fastify.io/) instead of [Express](https://expressjs.com/) for native TypeScript support and fast response
-- Use [alpine](https://hub.docker.com/_/alpine) for less image size in Docker
 - You can Change User Agent and Accept Language etc with environment variables
 - Bearer token authorization Support
 
@@ -63,21 +62,21 @@ And build image.
 docker build -t hc-pdf-server:latest .
 ```
 
-##### 2. From apk package
+##### 2. From package
 You can use build-arg `ADDITONAL_FONTS` as package names.
 
 See below available font package names.
 
-https://wiki.alpinelinux.org/wiki/Fonts
+https://packages.debian.org/stable/fonts/
 
 ```zsh
 docker build \
-  --build-arg ADDITONAL_FONTS=font-noto-cjk \
+  --build-arg ADDITONAL_FONTS=fonts-ipafont \
   -t hc-pdf-server:latest .
 
 # multiple (split by space)
 docker build \
-  --build-arg ADDITONAL_FONTS="font-noto-cjk font-ipa" \
+  --build-arg ADDITONAL_FONTS="fonts-ipafont fonts-ipaexfont-gothic" \
   -t hc-pdf-server:latest .
 ```
 #### Run docker


### PR DESCRIPTION
This change was made because the final image size is more than 100MB smaller using `node:15-buster-slim` than using `node:15-alpine3.12`.

I've kept the alpine version as `Dockerfile.alpine`.

```
hc-pdf-server                                   15-buster-slim   7ea1a53bb498   4 minutes ago   828MB
hc-pdf-server                                   15-alpine3       05115870ea6c   2 hours ago     972MB
```

# Breaking Change
Build arg `ADDITONAL_FONTS` must be a Debian font package names.