### PR TITLE
Fix  Broken after  Timeout errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/uyamazak/hc-pdf-server#readme",
   "dependencies": {
-    "@uyamazak/fastify-hc-pages": "^1.0.6",
+    "@uyamazak/fastify-hc-pages": "^1.0.8",
     "fastify": "^3.27.0",
     "fastify-bearer-auth": "^6.1.0",
     "fastify-formbody": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/uyamazak/hc-pdf-server#readme",
   "dependencies": {
-    "@uyamazak/fastify-hc-pages": "^1.0.8",
+    "@uyamazak/fastify-hc-pages": "1.0.9",
     "fastify": "^3.27.0",
     "fastify-bearer-auth": "^6.1.0",
     "fastify-formbody": "^5.2.0",
@@ -38,7 +38,7 @@
     "puppeteer": "^11.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.9",
+    "@tsconfig/node12": "^1.0.6",
     "@types/node": "^17.0.13",
     "@types/pdf-parse": "^1.1.1",
     "@types/tap": "^15.0.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "puppeteer": "^11.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node12": "^1.0.6",
+    "@tsconfig/node12": "^1.0.9",
     "@types/node": "^17.0.13",
     "@types/pdf-parse": "^1.1.1",
     "@types/tap": "^15.0.5",

--- a/test/requests/get-timeout.test.ts
+++ b/test/requests/get-timeout.test.ts
@@ -1,0 +1,47 @@
+import { test } from 'tap'
+import { InjectOptions, Response } from 'light-my-request'
+import { app } from '../../src/app'
+import { TEST_TARGET_URL } from '../../src/config'
+// For occur TimeoutError: Navigation timeout
+// https://stackoverflow.com/questions/100841/artificially-create-a-connection-timeout-error
+const WRONG_TEST_URL = 'http://10.255.255.1/'
+
+interface Test {
+  teardown(cb: unknown): unknown
+}
+async function build(t: Test) {
+  const myApp = await app({ pagesNum: 3, pageTimeoutMilliseconds: 2000 })
+  t.teardown(myApp.close.bind(myApp))
+  return myApp
+}
+
+test('success after 10 times timeout requests ', async (t) => {
+  t.test('GET / with wrong url', async (t) => {
+    const app = await build(t)
+    const responses: Promise<Response>[] = []
+    for (let i = 0; i < 10; i++) {
+      responses.push(
+        app.inject({
+          method: 'GET',
+          url: '/',
+          query: {
+            url: WRONG_TEST_URL,
+          },
+        } as InjectOptions)
+      )
+    }
+    const results = await Promise.all(responses)
+    for (const r of results) {
+      t.equal(r.statusCode, 500)
+    }
+    const successRes = await app.inject({
+      method: 'GET',
+      url: '/',
+      query: {
+        url: TEST_TARGET_URL,
+      },
+    } as InjectOptions)
+    t.equal(successRes.statusCode, 200)
+    t.end()
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,10 +518,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uyamazak/fastify-hc-pages@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@uyamazak/fastify-hc-pages/-/fastify-hc-pages-1.0.6.tgz#1c752fc8699e1f436efd62095f9a8236a8a1b739"
-  integrity sha512-6gfIULu+sU9pRaHss+OnAMXiXrbR/bwJZ1dl439uHYRMcK0gD5rhAsQS1MTZwkytpTdirOm3e9zagv3UKw6V6Q==
+"@uyamazak/fastify-hc-pages@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@uyamazak/fastify-hc-pages/-/fastify-hc-pages-1.0.8.tgz#372df042f41dec9946ab363e0c36fedd99b32f01"
+  integrity sha512-7LHmpKKy/ftB3iGQ0pi2GZeBdBdfgY4K3+zeIqxylNYiGod4A8/NneOK8smHxtL4FQGXlS5X260M/+5mkwQgkA==
   dependencies:
     fastify-plugin "^3.0.0"
     puppeteer "^11.0.0"
@@ -2118,7 +2118,6 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 
 "import-jsx@github:isaacs/import-jsx":
   version "4.0.0"
-  uid ece90f14b08390adef8cc7cf42a757ab121d991a
   resolved "https://codeload.github.com/isaacs/import-jsx/tar.gz/ece90f14b08390adef8cc7cf42a757ab121d991a"
   dependencies:
     "@babel/core" "^7.5.5"
@@ -3743,15 +3742,15 @@ tap@^15.1.6:
   resolved "https://registry.yarnpkg.com/tap/-/tap-15.1.6.tgz#dc393e17bead934a2ee734d6124928694f2da2db"
   integrity sha512-TN7xH6Q2tUPTd6qwmkhuFJcx1vUR8e4dDUpBKc61G0krOzne7Ia6aKIFb8O/0kVazachSSuVME1V8nQ2xwWL8w==
   dependencies:
-    "@isaacs/import-jsx" "*"
-    "@types/react" "*"
+    "@isaacs/import-jsx" "^4.0.1"
+    "@types/react" "^17"
     chokidar "^3.3.0"
     coveralls "^3.0.11"
     findit "^2.0.0"
     foreground-child "^2.0.0"
     fs-exists-cached "^1.0.0"
     glob "^7.1.6"
-    ink "*"
+    ink "^3.2.0"
     isexe "^2.0.0"
     istanbul-lib-processinfo "^2.0.2"
     jackspeak "^1.4.1"
@@ -3760,7 +3759,7 @@ tap@^15.1.6:
     mkdirp "^1.0.4"
     nyc "^15.1.0"
     opener "^1.5.1"
-    react "*"
+    react "^17.0.2"
     rimraf "^3.0.0"
     signal-exit "^3.0.6"
     source-map-support "^0.5.16"
@@ -3768,7 +3767,7 @@ tap@^15.1.6:
     tap-parser "^10.0.1"
     tap-yaml "^1.0.0"
     tcompare "^5.0.7"
-    treport "*"
+    treport "^3.0.2"
     which "^2.0.2"
 
 tar-fs@2.1.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,7 +375,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
   integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
 
-"@tsconfig/node12@^1.0.6", "@tsconfig/node12@^1.0.7":
+"@tsconfig/node12@^1.0.7", "@tsconfig/node12@^1.0.9":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
   integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,7 +318,7 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@isaacs/import-jsx@*":
+"@isaacs/import-jsx@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/import-jsx/-/import-jsx-4.0.1.tgz#493cab5fc543a0703dba7c3f5947d6499028a169"
   integrity sha512-l34FEsEqpdYdGcQjRCxWy+7rHY6euUbOBz9FI+Mq6oQeVhNegHcXFSJxVxrJvOpO31NbnDjS74quKXDlPDearA==
@@ -375,7 +375,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
   integrity sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==
 
-"@tsconfig/node12@^1.0.7", "@tsconfig/node12@^1.0.9":
+"@tsconfig/node12@^1.0.6", "@tsconfig/node12@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.9.tgz#62c1f6dee2ebd9aead80dc3afa56810e58e1a04c"
   integrity sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==
@@ -415,10 +415,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react@*":
-  version "17.0.35"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.35.tgz#217164cf830267d56cd1aec09dcf25a541eedd4c"
-  integrity sha512-r3C8/TJuri/SLZiiwwxQoLAoavaczARfT9up9b4Jr65+ErAUX3MIkU0oMOQnrpfgHme8zIqZLX7O5nnjm5Wayw==
+"@types/react@^17":
+  version "17.0.39"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.39.tgz#d0f4cde092502a6db00a1cded6e6bf2abb7633ce"
+  integrity sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -518,10 +518,10 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@uyamazak/fastify-hc-pages@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@uyamazak/fastify-hc-pages/-/fastify-hc-pages-1.0.8.tgz#372df042f41dec9946ab363e0c36fedd99b32f01"
-  integrity sha512-7LHmpKKy/ftB3iGQ0pi2GZeBdBdfgY4K3+zeIqxylNYiGod4A8/NneOK8smHxtL4FQGXlS5X260M/+5mkwQgkA==
+"@uyamazak/fastify-hc-pages@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@uyamazak/fastify-hc-pages/-/fastify-hc-pages-1.0.9.tgz#b9fea6f6ceb589ce2a79ee68858071fbe6dba206"
+  integrity sha512-ZfhM6BeRv7rRgC6ccBKrSOdOZfjGWF4GETwrsxNIfcAZXZRNQrD0kWP68PjcSDC/krXWlntqojHE4Cs+rAtKZA==
   dependencies:
     fastify-plugin "^3.0.0"
     puppeteer "^11.0.0"
@@ -2116,20 +2116,6 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-"import-jsx@github:isaacs/import-jsx":
-  version "4.0.0"
-  resolved "https://codeload.github.com/isaacs/import-jsx/tar.gz/ece90f14b08390adef8cc7cf42a757ab121d991a"
-  dependencies:
-    "@babel/core" "^7.5.5"
-    "@babel/plugin-proposal-object-rest-spread" "^7.5.5"
-    "@babel/plugin-transform-destructuring" "^7.5.0"
-    "@babel/plugin-transform-react-jsx" "^7.3.0"
-    caller-path "^3.0.1"
-    find-cache-dir "^3.2.0"
-    make-dir "^3.0.2"
-    resolve-from "^3.0.0"
-    rimraf "^3.0.0"
-
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -2153,7 +2139,7 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ink@*, ink@^3.2.0:
+ink@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ink/-/ink-3.2.0.tgz#434793630dc57d611c8fe8fffa1db6b56f1a16bb"
   integrity sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==
@@ -3238,7 +3224,7 @@ react-reconciler@^0.26.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react@*:
+react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -3857,14 +3843,14 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-treport@*:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/treport/-/treport-3.0.0.tgz#b422d4aac6e25cd02fd50e0f785a1ef23035df08"
-  integrity sha512-CtLvd0/HXLVQTwKIcNt08zpQ6Li83BVe6rDhkhUv64Mo9Ykz0LKPZA8QXKsSKY2EXmQGIcYaOxqAxgqQ9E77YQ==
+treport@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/treport/-/treport-3.0.2.tgz#6503b6430b201620a20fef2892bc875dc6495116"
+  integrity sha512-aMKalaiZMsTfTXIEnJEz7BT5aHzN+ZV5hFCrXZsCbRZxfGRop+7JQdXntBs1FHZc9W2zMHLxGHb42yf08l6/bw==
   dependencies:
+    "@isaacs/import-jsx" "^4.0.1"
     cardinal "^2.1.1"
     chalk "^3.0.0"
-    import-jsx "github:isaacs/import-jsx"
     ink "^3.2.0"
     ms "^2.1.2"
     tap-parser "^10.0.1"


### PR DESCRIPTION
Fixed in fastify-hc-pages@1.0.9, so upgrade it.
https://github.com/uyamazak/fastify-hc-pages/releases/tag/v1.0.9

And add virtual timeout error test, using non-routable IP address.

test/requests/get-timeout.test.ts

Related
https://github.com/uyamazak/hc-pdf-server/discussions/450