### PR TITLE
Add env variable for changing browser launch option args

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ default: false
 default: false
 
 ## Browser Launch Options
-### HCEP_DEFAULT_DEFAULT_BROWSER_LAUNCH_ARGS
+### HCEP_DEFAULT_BROWSER_LAUNCH_ARGS
 `args` of browser launch options. Space separated needed.
 
 default: '--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-dev-shm-usage'

--- a/README.md
+++ b/README.md
@@ -333,9 +333,9 @@ default: false
 
 ## Browser Launch Options
 ### HCEP_DEFAULT_BROWSER_LAUNCH_ARGS
-`args` of browser launch options. Space separated needed.
+`args` of browser launch options. Comma separated string needed.
 
-default: '--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-dev-shm-usage'
+default: '--no-sandbox,--disable-setuid-sandbox,--disable-gpu,--disable-dev-shm-usage'
 
 see [puppeteer.launch](https://pptr.dev/#?product=Puppeteer&version=v13.5.2&show=api-puppeteerlaunchoptions)
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ default: false
 default: false
 ### HCPDF_VIEWPORT_IS_LANDSCAPE
 default: false
+
+## Browser Launch Options
+### HCEP_DEFAULT_DEFAULT_BROWSER_LAUNCH_ARGS
+`args` of browser launch options. Space separated needed.
+
+default: '--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-dev-shm-usage'
+
+see [puppeteer.launch](https://pptr.dev/#?product=Puppeteer&version=v13.5.2&show=api-puppeteerlaunchoptions)
+
 ## Others
 Other settings can be changed by environment variables.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-pdf-server",
-  "version": "2.0.3",
+  "version": "2.1.3",
   "description": "html to pdf rendering server using Headless Chrome",
   "main": "dist/server.js",
   "directories": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -59,7 +59,7 @@ const defaultAppConfig: AppConfig = {
 
 const buildBrowserLaunchArgs = (): BrowserLaunchArgumentOptions => {
   return {
-    args: BROWSER_LAUNCH_ARGS.split(' '),
+    args: BROWSER_LAUNCH_ARGS.trim().split(','),
   }
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,7 @@
 import fastify, { FastifyInstance } from 'fastify'
 import formBody from 'fastify-formbody'
 import bearerAuthPlugin from 'fastify-bearer-auth'
-import { Page } from 'puppeteer'
+import { Page, BrowserLaunchArgumentOptions } from 'puppeteer'
 import { hcPages } from '@uyamazak/fastify-hc-pages'
 import { hcPDFOptionsPlugin } from './plugins/pdf-options'
 import { AppConfig, GetQuerystring, PostBody } from './types/hc-pdf-server'
@@ -17,6 +17,7 @@ import {
   FASTIFY_LOG_LEVEL,
   FASTIFY_BODY_LIMIT,
   DEFAULT_VIEWPORT,
+  BROWSER_LAUNCH_ARGS,
 } from './config'
 
 const getSchema = {
@@ -56,6 +57,12 @@ const defaultAppConfig: AppConfig = {
   viewport: DEFAULT_VIEWPORT,
 }
 
+const buildBrowserLaunchArgs = (): BrowserLaunchArgumentOptions => {
+  return {
+    args: BROWSER_LAUNCH_ARGS.split(' '),
+  }
+}
+
 export const app = async (
   appConfig = {} as Partial<AppConfig>
 ): Promise<FastifyInstance> => {
@@ -90,6 +97,7 @@ export const app = async (
       acceptLanguage,
       viewport,
     },
+    launchOptions: buildBrowserLaunchArgs(),
   })
 
   if (bearerAuthSecretKey) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -88,16 +88,20 @@ export const app = async (
     filePath: presetPdfOptionsFilePath,
   })
   server.register(formBody)
+  const pageOptions = {
+    userAgent,
+    pageTimeoutMilliseconds,
+    emulateMediaTypeScreenEnabled,
+    acceptLanguage,
+    viewport,
+  }
+  console.debug('pageOptions:', pageOptions)
+  const launchOptions = buildBrowserLaunchArgs()
+  console.debug('launchOptions:', launchOptions)
   server.register(hcPages, {
     pagesNum,
-    pageOptions: {
-      userAgent,
-      pageTimeoutMilliseconds,
-      emulateMediaTypeScreenEnabled,
-      acceptLanguage,
-      viewport,
-    },
-    launchOptions: buildBrowserLaunchArgs(),
+    pageOptions,
+    launchOptions,
   })
 
   if (bearerAuthSecretKey) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { PaperFormat } from 'puppeteer'
+import { PaperFormat, BrowserLaunchArgumentOptions } from 'puppeteer'
 
 const toBoolean = (val: string | undefined) => {
   return val === 'true'
@@ -87,3 +87,9 @@ export const DEFAULT_VIEWPORT = {
   isLandscape: toBoolean(process.env.HCPDF_VIEWPORT_HAS_TOUCH),
   hasTouch: toBoolean(process.env.HCPDF_VIEWPORT_IS_LANDSCAPE),
 }
+
+const DEFAULT_BROWSER_LAUNCH_ARGS =
+  '--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-dev-shm-usage'
+export const BROWSER_LAUNCH_ARGS =
+  process.env.HCEP_DEFAULT_DEFAULT_BROWSER_LAUNCH_ARGS ??
+  DEFAULT_BROWSER_LAUNCH_ARGS

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { PaperFormat, BrowserLaunchArgumentOptions } from 'puppeteer'
+import { PaperFormat } from 'puppeteer'
 
 const toBoolean = (val: string | undefined) => {
   return val === 'true'

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,6 +89,6 @@ export const DEFAULT_VIEWPORT = {
 }
 
 const DEFAULT_BROWSER_LAUNCH_ARGS =
-  '--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-dev-shm-usage'
+  '--no-sandbox,--disable-setuid-sandbox,--disable-gpu,--disable-dev-shm-usage'
 export const BROWSER_LAUNCH_ARGS =
   process.env.HCEP_DEFAULT_BROWSER_LAUNCH_ARGS ?? DEFAULT_BROWSER_LAUNCH_ARGS

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,5 +91,4 @@ export const DEFAULT_VIEWPORT = {
 const DEFAULT_BROWSER_LAUNCH_ARGS =
   '--no-sandbox --disable-setuid-sandbox --disable-gpu --disable-dev-shm-usage'
 export const BROWSER_LAUNCH_ARGS =
-  process.env.HCEP_DEFAULT_DEFAULT_BROWSER_LAUNCH_ARGS ??
-  DEFAULT_BROWSER_LAUNCH_ARGS
+  process.env.HCEP_DEFAULT_BROWSER_LAUNCH_ARGS ?? DEFAULT_BROWSER_LAUNCH_ARGS


### PR DESCRIPTION
The previously hard-coded Launch Options args can now be changed via environment variable 'HCEP_DEFAULT_BROWSER_LAUNCH_ARGS'.

Related: https://github.com/uyamazak/hc-pdf-server/discussions/450