### PR TITLE
add --platform for build in other platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # https://github.com/uyamazak/hc-pdf-server
-FROM node:18-buster-slim as package_install
+FROM --platform=linux/amd64 node:18-buster-slim as package_install
 LABEL maintainer="uyamazak<yu.yamazaki85@gmail.com>"
 COPY package.json yarn.lock /app/
 WORKDIR /app
@@ -9,7 +9,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
 RUN ["yarn", "install", "--frozen-lockfile"]
 
 
-FROM node:18-buster-slim
+FROM --platform=linux/amd64 node:18-buster-slim
 # Fastify in docker needs 0.0.0.0
 # https://github.com/fastify/fastify/issues/935
 ENV HCPDF_SERVER_ADDRESS=0.0.0.0


### PR DESCRIPTION
close https://github.com/uyamazak/hc-pdf-server/issues/612

The following error occurred when performing docker build in M1's Mac environment.

```
#6 14.26 Current default time zone: 'Etc/UTC'
#6 14.27 Local time is now:      Thu Mar 30 00:57:29 UTC 2023.
#6 14.27 Universal Time is now:  Thu Mar 30 00:57:29 UTC 2023.
#6 14.27 Run 'dpkg-reconfigure tzdata' if you wish to change it.
#6 14.27 
#6 14.31 Reading package lists...
#6 15.22 Building dependency tree...
#6 15.34 Reading state information...
#6 15.44 E: Unable to locate package google-chrome-stable
------
executor failed running [/bin/sh -c apt-get update   && apt-get install -y wget gnupg   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'   && apt-get update && apt-get upgrade -y   && apt-get install -y google-chrome-stable ${ADDITONAL_FONTS} fonts-freefont-ttf libxss1   --no-install-recommends   && rm -rf /var/lib/apt/lists/*]: exit code: 100
~/hc-pdf-server:(upgrade_puppeteer_19) $ docker build -t hc-pdf-server:latest .
```

The build was successfully completed by adding the platform specification with reference to the following
https://dev.to/docker/unable-to-locate-package-google-chrome-stable-b62